### PR TITLE
args added to toggle major version folder in path

### DIFF
--- a/chromedriver_autoinstaller_fix/__init__.py
+++ b/chromedriver_autoinstaller_fix/__init__.py
@@ -7,7 +7,7 @@ from typing import AnyStr, Optional
 from . import utils
 
 
-def install(cwd: bool = False, path: Optional[AnyStr] = None, no_ssl: bool = False):
+def install(cwd: bool = False, path: Optional[AnyStr] = None, path_inc_major: bool = True, no_ssl: bool = False):
     """
     Appends the directory of the chromedriver binary file to PATH.
 
@@ -18,7 +18,7 @@ def install(cwd: bool = False, path: Optional[AnyStr] = None, no_ssl: bool = Fal
     """
     if cwd:
         path = os.getcwd()
-    chromedriver_filepath = utils.download_chromedriver(path, no_ssl)
+    chromedriver_filepath = utils.download_chromedriver(path, path_inc_major, no_ssl)
     if not chromedriver_filepath:
         logging.debug("Can not download chromedriver.")
         return

--- a/chromedriver_autoinstaller_fix/utils.py
+++ b/chromedriver_autoinstaller_fix/utils.py
@@ -280,7 +280,7 @@ def print_chromedriver_path():
     print(get_chromedriver_path())
 
 
-def download_chromedriver(path: Optional[AnyStr] = None, no_ssl: bool = False):
+def download_chromedriver(path: Optional[AnyStr] = None, path_inc_major: bool = True, no_ssl: bool = False):
     """
     Downloads, unzips and installs chromedriver.
     If a chromedriver binary is found in PATH it will be copied, otherwise downloaded.
@@ -307,11 +307,11 @@ def download_chromedriver(path: Optional[AnyStr] = None, no_ssl: bool = False):
     if path:
         if not os.path.isdir(path):
             raise ValueError(f"Invalid path: {path}")
-        chromedriver_dir = os.path.join(os.path.abspath(path), major_version)
+        chromedriver_dir = os.path.join(os.path.abspath(path), major_version) if path_inc_major else os.path.abspath(path)
     else:
         chromedriver_dir = os.path.join(
             os.path.abspath(os.path.dirname(__file__)), major_version
-        )
+        ) if path_inc_major else os.path.abspath(os.path.dirname(__file__))
     chromedriver_filename = get_chromedriver_filename()
     chromedriver_filepath = os.path.join(chromedriver_dir, chromedriver_filename)
     if not os.path.isfile(chromedriver_filepath) or not check_version(


### PR DESCRIPTION
See original conversation here: https://github.com/yeongbin-jo/python-chromedriver-autoinstaller/issues/34

Currently, chromedriver is being installed within a folder named after the current major version, however the path that chromedriver is installed into should be left up to the person using it, and assumptions like putting it into a major version-named folder should not be made. The original dev mentioned looking into making changes to resolve this without breaking current functionality, and I feel like this could be one way of doing so.